### PR TITLE
Fix FreeBSD support

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -19,8 +19,9 @@ ifeq ($(UNAME_SYS), Darwin)
 	LDFLAGS ?= -arch x86_64 -flat_namespace -undefined suppress
 else ifeq ($(UNAME_SYS), FreeBSD)
 	CC ?= cc
-	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
+	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes -I /usr/local/include
 	CXXFLAGS ?= -O3 -finline-functions -Wall
+	LDFLAGS ?= -fPIC -L /usr/local/lib
 else ifeq ($(UNAME_SYS), Linux)
 	CC ?= gcc
 	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,7 @@
 {erl_opts, [debug_info]}.
 
-{pre_hooks, [
-	{compile, "make -C c_src"},
-	{clean, "make -C c_src clean"}
+{pre_hooks, [{"freebsd", compile, "gmake -C c_src"},
+             {"freebsd", clean, "gmake -C c_src clean"},
+             {"(linux|darwin|solaris)", compile, "make -C c_src"},
+             {"(linux|darwin|solaris)", clean, "make -C c_src clean"}
 ]}.


### PR DESCRIPTION
Hi @jlouis,

I was not able to get `enacl` compiled and running in FreeBSD so I tried to tweak the `rebar.conf` and some other parameters in order to get it working.

I think the rebar pre_hook is appropriate however I have no experience with rebar3.

Tell me what you think, cheers!