### PR TITLE
Expose Seal Box functions

### DIFF
--- a/src/enacl.erl
+++ b/src/enacl.erl
@@ -429,8 +429,8 @@ box_secret_key_bytes() ->
        PK :: binary(),
        SealedCipherText :: binary().
 seal_box(Msg, PK) ->
-      enacl_nif:crypto_box_seal(Msg, PK).
-
+  enacl_nif:crypto_box_seal(Msg, PK).
+ 
 %% @doc seal_box_open/3 decrypts+check message integrity from an unknown sender.
 %%
 %% Decrypt a `SealedCipherText' which contains an ephemeral public key from another party
@@ -443,7 +443,10 @@ seal_box(Msg, PK) ->
       SK :: binary(),
       Msg :: binary().
 seal_box_open(SealedCipherText, PK, SK) ->
-  enacl_nif:crypto_box_seal_open(SealedCipherText, PK, SK).
+  case enacl_nif:crypto_box_seal_open(SealedCipherText, PK, SK) of
+    {error, Err} -> {error, Err};
+    Bin when is_binary(Bin) -> Bin
+  end.
 
 %% @doc secretbox/3 encrypts a message with a key
 %%

--- a/src/enacl_nif.erl
+++ b/src/enacl_nif.erl
@@ -33,8 +33,12 @@
 	crypto_sign_open/2,
 	crypto_sign_open_b/2,
 
-        crypto_sign_detached/2,
-        crypto_sign_verify_detached/3
+	crypto_sign_detached/2,
+	crypto_sign_verify_detached/3,
+
+	crypto_box_seal/2,
+	crypto_box_seal_open/3,
+	crypto_box_SEALBYTES/0
 
 ]).
 
@@ -150,6 +154,10 @@ crypto_sign_open_b(_SignedMessage, _PK) -> erlang:nif_error(nif_not_loaded).
 
 crypto_sign_detached(_M, _SK) -> erlang:nif_error(nif_not_loaded).
 crypto_sign_verify_detached(_SIG, _M, _PK) -> erlang:nif_error(nif_not_loaded).
+
+crypto_box_seal(_Msg, _PK) -> erlang:nif_error(nif_not_loaded).
+crypto_box_seal_open(_CipherText, _PK, _SK) -> erlang:nif_error(nif_not_loaded).
+crypto_box_SEALBYTES() -> erlang:nif_error(nif_not_loaded).
 
 crypto_secretbox_NONCEBYTES() -> erlang:nif_error(nif_not_loaded).
 crypto_secretbox_ZEROBYTES() -> erlang:nif_error(nif_not_loaded).


### PR DESCRIPTION
This patch exposes libsodium's seal box functions which create encryption key pairs behind the scene, So someone can send data to another party just by party's public key.