### PR TITLE
Force remove artifacts in clean target.

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -72,4 +72,4 @@ $(C_SRC_OUTPUT): $(OBJECTS)
 	$(COMPILE_CPP) $(OUTPUT_OPTION) $<
 
 clean:
-	@rm $(C_SRC_OUTPUT) $(OBJECTS)
+	@rm -f $(C_SRC_OUTPUT) $(OBJECTS)


### PR DESCRIPTION
Currently `make clean` (or `rebar3 clean`) fails if the project has not been built first. This interferes with some automation that starts by cleaning projects before rebuilding (for example when building a deb package, `dpkg-buildpackage` starts with a rule `clean`).