### PR TITLE
Curve25519 scalar multiplication with base point

### DIFF
--- a/c_src/enacl_nif.c
+++ b/c_src/enacl_nif.c
@@ -149,7 +149,7 @@ ERL_NIF_TERM enif_crypto_curve25519_scalarmult_base(ErlNifEnv *env, int argc, ER
 		}
 
 		if (crypto_scalarmult_curve25519_base(output.data, secret.data) < 0) {
-			result = nacl_error_tuple(env, "scalarmult_curve25519_failed");
+			result = nacl_error_tuple(env, "scalarmult_curve25519_base_failed");
 			continue;
 		}
 

--- a/c_src/enacl_nif.c
+++ b/c_src/enacl_nif.c
@@ -131,6 +131,34 @@ ERL_NIF_TERM enif_crypto_curve25519_scalarmult(ErlNifEnv *env, int argc, ERL_NIF
 	return result;
 }
 
+static
+ERL_NIF_TERM enif_crypto_curve25519_scalarmult_base(ErlNifEnv *env, int argc, ERL_NIF_TERM const argv[]) {
+	ERL_NIF_TERM result;
+	ErlNifBinary secret, output;
+
+	if ((argc != 1) || (!enif_inspect_binary(env, argv[0], &secret))
+	                || (secret.size != crypto_scalarmult_curve25519_BYTES)) {
+		return enif_make_badarg(env);
+	}
+
+	do
+	{
+		if (!enif_alloc_binary(crypto_scalarmult_curve25519_BYTES, &output)) {
+			result = nacl_error_tuple(env, "alloc_failed");
+			continue;
+		}
+
+		if (crypto_scalarmult_curve25519_base(output.data, secret.data) < 0) {
+			result = nacl_error_tuple(env, "scalarmult_curve25519_failed");
+			continue;
+		}
+
+		result = enif_make_binary(env, &output);
+	} while (0);
+
+	return result;
+}
+
 /* Ed 25519 */
 static
 ERL_NIF_TERM enif_crypto_sign_ed25519_keypair(ErlNifEnv *env, int argc, ERL_NIF_TERM const argv[]) {
@@ -1186,6 +1214,7 @@ static ErlNifFunc nif_funcs[] = {
 	{"sodium_memzero", 1, enif_sodium_memzero},
 
 	{"crypto_curve25519_scalarmult", 2, enif_crypto_curve25519_scalarmult, ERL_NIF_DIRTY_JOB_CPU_BOUND},
+	{"crypto_curve25519_scalarmult_base", 1, enif_crypto_curve25519_scalarmult_base, ERL_NIF_DIRTY_JOB_CPU_BOUND},
 
 	{"crypto_sign_ed25519_keypair", 0, enif_crypto_sign_ed25519_keypair, ERL_NIF_DIRTY_JOB_CPU_BOUND},
 	{"crypto_sign_ed25519_public_to_curve25519", 1, enif_crypto_sign_ed25519_public_to_curve25519},

--- a/src/enacl.erl
+++ b/src/enacl.erl
@@ -76,7 +76,9 @@
 
 %% Curve 25519.
 -export([
-	curve25519_scalarmult/1, curve25519_scalarmult/2
+	curve25519_scalarmult/1,
+	curve25519_scalarmult/2,
+	curve25519_scalarmult_base/1
 ]).
 
 %% Ed 25519.
@@ -773,6 +775,11 @@ curve25519_scalarmult(Secret, BasePoint) ->
 %% @end
 curve25519_scalarmult(#{ secret := Secret, base_point := BasePoint }) ->
     curve25519_scalarmult(Secret, BasePoint).
+
+%% @doc curve25519_scalarmult_base/1 does scalar multiplication between Secret and the
+%% Curve25519 basepoint.
+curve25519_scalarmult_base(Secret) ->
+    enacl_nif:crypto_curve25519_scalarmult_base(Secret).
 
 %% Ed 25519 Crypto
 %% ---------------

--- a/src/enacl_ext.erl
+++ b/src/enacl_ext.erl
@@ -49,7 +49,7 @@ curve25519_keypair() ->
 %% @end
 -spec curve25519_public_key(SecretKey :: binary()) -> binary().
 curve25519_public_key(SecretKey) ->
-	enacl:curve25519_scalarmult(SecretKey, <<9, 0:248>>).
+	enacl:curve25519_scalarmult_base(SecretKey).
 
 %% @doc curve25519_shared/2 creates a new shared secret from a given SecretKey and PublicKey.
 %% @end.

--- a/src/enacl_nif.erl
+++ b/src/enacl_nif.erl
@@ -92,7 +92,8 @@
 
 %% Curve25519
 -export([
-	crypto_curve25519_scalarmult/2
+	crypto_curve25519_scalarmult/2,
+	crypto_curve25519_scalarmult_base/1
 ]).
 
 %% Ed 25519
@@ -210,6 +211,7 @@ crypto_onetimeauth_verify(_Authenticator, _Msg, _Key) -> erlang:nif_error(nif_no
 crypto_onetimeauth_verify_b(_Authenticator, _Msg, _Key) -> erlang:nif_error(nif_not_loaded).
 
 crypto_curve25519_scalarmult(_Secret, _BasePoint) -> erlang:nif_error(nif_not_loaded).
+crypto_curve25519_scalarmult_base(_Secret) -> erlang:nif_error(nif_not_loaded).
 
 crypto_sign_ed25519_keypair() -> erlang:nif_error(nif_not_loaded).
 crypto_sign_ed25519_public_to_curve25519(_PublicKey) -> erlang:nif_error(nif_not_loaded).


### PR DESCRIPTION
Added the function to do scalar multiplication with the basepoint of curve25519. This could be done just using the encoded basepoint as in enacl_ext but since the function exist in libsodium it ought to be used.