### PR TITLE
Don't assume 64bits for size_t

### DIFF
--- a/c_src/enacl_nif.c
+++ b/c_src/enacl_nif.c
@@ -1012,7 +1012,7 @@ ERL_NIF_TERM enif_crypto_onetimeauth_verify(ErlNifEnv *env, int argc, ERL_NIF_TE
 static
 ERL_NIF_TERM enif_randombytes(ErlNifEnv *env, int argc, ERL_NIF_TERM const argv[])
 {
-	size_t req_size;
+	unsigned req_size;
 	ErlNifBinary result;
 
 	if ((argc != 1) || (!enif_get_uint(env, argv[0], &req_size))) {

--- a/c_src/enacl_nif.c
+++ b/c_src/enacl_nif.c
@@ -1015,7 +1015,7 @@ ERL_NIF_TERM enif_randombytes(ErlNifEnv *env, int argc, ERL_NIF_TERM const argv[
 	size_t req_size;
 	ErlNifBinary result;
 
-	if ((argc != 1) || (!enif_get_uint64(env, argv[0], &req_size))) {
+	if ((argc != 1) || (!enif_get_uint(env, argv[0], &req_size))) {
 		return enif_make_badarg(env);
 	}
 


### PR DESCRIPTION
On non-64bit platforms, `size_t` may not be 64bits. This means a call to `enif_get_uint64` with a pointer-to-`size_t` passed in could result in data corruption on smaller-than-64bit platforms (especially on big-endian platforms, where corruption will definitely occur even for small values).

However, the Erlang Nif system doesn't provide a function to get a `size_t` from the environment passed into a function. A more-platform-agnostic choice is `enif_get_uint`, with a pointer-to-`unsigned int` passed as parameter.

In the spot where this change is made, the resulting value, the requested size of a hash, is used in a call to `enif_alloc_binary`, which takes a `size_t` size parameter. This means we now have a type mismatch. However, this should be fine, because the `ErlNifBinary` types store their size as an `unsigned int` anyhow, so requesting an allocation size as an `unsigned int` should be fine (in fact, the `enacl` code does this in many places, wherever `enif_alloc_binary` is called with a `ErlNifBinary.size` passed in as parameter).