### PR TITLE
Expose XChaCha20-Poly1305 construction

### DIFF
--- a/eqc_test/enacl_eqc.erl
+++ b/eqc_test/enacl_eqc.erl
@@ -544,6 +544,155 @@ prop_aead_chacha20poly1305_fail() ->
     end
   end).
 
+
+%% AEAD XChaCha20Poly1305
+%% ------------------------------------------------------------
+%% * aead_chacha20poly1305_encrypt/4,
+%% * aead_chacha20poly1305_decrypt/4,
+prop_aead_xchacha20poly1305_ietf() ->
+  ?FORALL({Msg, Ad, Nonce, Key},
+          {binary(), binary(), binary(24), binary(32)},
+  begin
+    EncryptMsg = enacl:aead_xchacha20poly1305_ietf_encrypt(Msg, Ad, Nonce, Key),
+    equals(enacl:aead_xchacha20poly1305_ietf_decrypt(EncryptMsg, Ad, Nonce, Key), Msg)
+  end).
+
+prop_nonce() ->
+  ?FORALL({},{},
+  begin
+    Props = [
+         {stream, 24}, 
+         {stream_chacha20, 8}, 
+         {aead_chacha20poly1305_ietf, 12},
+         {aead_xchacha20poly1305_ietf, 24}
+        ],
+    Pred = fun({N,S}) -> erlang:size(enacl:nonce(N)) == S end, 
+    [] = lists:dropwhile(Pred, Props),
+    true
+  end).
+
+prop_nonce_fail() ->
+  ?FORALL({},{},
+  begin
+    case enacl:nonce(bad_nonce_type) of 
+        {error, unknown_nonce} -> true;
+        _ -> false
+    end
+  end).
+
+prop_aead_xchacha20poly1305_ietf_keygen() ->
+  ?FORALL({},{},
+  begin
+    K = enacl:aead_xchacha20poly1305_ietf_keygen(),
+    equals(erlang:size(K), 32)
+  end).
+
+prop_aead_xchacha20poly1305_ietf_msg_fail() ->
+  ?FORALL({Msg, Ad, Nonce, Key},
+          {binary(), binary(), binary(24), binary(32)},
+  begin
+    EncryptMsg = enacl:aead_xchacha20poly1305_ietf_encrypt(Msg, Ad, Nonce, Key),
+    case enacl:aead_xchacha20poly1305_ietf_decrypt(<<0:8, EncryptMsg/binary>>,
+                                                   Ad, Nonce, Key) of
+        {error, _} -> true;
+        _          -> false
+    end
+  end).
+
+prop_aead_xchacha20poly1305_ietf_ad_fail() ->
+  ?FORALL({Msg, Ad, Nonce, Key},
+          {binary(), binary(), binary(24), binary(32)},
+  begin
+    EncryptMsg = enacl:aead_xchacha20poly1305_ietf_encrypt(Msg, Ad, Nonce, Key),
+    case enacl:aead_xchacha20poly1305_ietf_decrypt(EncryptMsg, <<0:8, Ad/binary>>, Nonce, Key) of
+        {error, _} -> true;
+        _          -> false
+    end
+  end).
+
+prop_aead_xchacha20poly1305_ietf_nonce_fail() ->
+  ?FORALL({Msg, Ad, Nonce, Key, BadNonce},
+          {binary(), binary(), binary(24), binary(32), binary(24)},
+  begin
+    EncryptMsg = enacl:aead_xchacha20poly1305_ietf_encrypt(Msg, Ad, Nonce, Key),
+    case enacl:aead_xchacha20poly1305_ietf_decrypt(EncryptMsg, Ad, BadNonce, Key) of
+        {error, _} -> true;
+        _          -> false
+    end
+  end).
+
+prop_aead_xchacha20poly1305_ietf_key_fail() ->
+  ?FORALL({Msg, Ad, Nonce, Key, BadKey},
+          {binary(), binary(), binary(24), binary(32), binary(32)},
+  begin
+    EncryptMsg = enacl:aead_xchacha20poly1305_ietf_encrypt(Msg, Ad, Nonce, Key),
+    case enacl:aead_xchacha20poly1305_ietf_decrypt(EncryptMsg, Ad, Nonce, BadKey) of
+        {error, _} -> true;
+        _          -> false
+    end
+  end).
+
+prop_aead_xchacha20poly1305_ietf_nonce_size_fail() ->
+  ?FORALL({Msg, Ad, UnderSizedNonce, OverSizedNonce, Key},
+          {binary(), binary(), binary(23), binary(25), binary(32)},
+  begin
+    try
+        enacl:aead_xchacha20poly1305_ietf_encrypt(Msg, Ad, UnderSizedNonce, Key),
+        false
+    catch
+        error:badarg -> true
+    end,
+    try
+        enacl:aead_xchacha20poly1305_ietf_decrypt(Msg, Ad, UnderSizedNonce, Key),
+        false
+    catch
+        error:badarg -> true
+    end,
+    try
+        enacl:aead_xchacha20poly1305_ietf_encrypt(Msg, Ad, OverSizedNonce, Key),
+        false
+    catch
+        error:badarg -> true
+    end,
+    try
+        enacl:aead_xchacha20poly1305_ietf_decrypt(Msg, Ad, OverSizedNonce, Key),
+        false
+    catch
+        error:badarg -> true
+    end
+  end).
+
+
+prop_aead_xchacha20poly1305_ietf_key_size_fail() ->
+  ?FORALL({Msg, Ad, Nonce, UnderSizedKey, OverSizedKey},
+          {binary(), binary(), binary(24), binary(31), binary(33)},
+  begin
+    try
+        enacl:aead_xchacha20poly1305_ietf_encrypt(Msg, Ad, Nonce, UnderSizedKey),
+        false
+    catch
+        error:badarg -> true
+    end,
+    try
+        enacl:aead_xchacha20poly1305_ietf_decrypt(Msg, Ad, Nonce, UnderSizedKey),
+        false
+    catch
+        error:badarg -> true
+    end,
+    try
+        enacl:aead_xchacha20poly1305_ietf_encrypt(Msg, Ad, Nonce, OverSizedKey),
+        false
+    catch
+        error:badarg -> true
+    end,
+    try
+        enacl:aead_xchacha20poly1305_ietf_decrypt(Msg, Ad, Nonce, OverSizedKey),
+        false
+    catch
+        error:badarg -> true
+    end
+  end).
+
 %% CRYPTO STREAM
 %% ------------------------------------------------------------
 %% * stream/3

--- a/src/enacl.erl
+++ b/src/enacl.erl
@@ -16,6 +16,9 @@
 %%% @end.
 -module(enacl).
 
+%% Helpers
+-export([nonce/1]).
+
 %% Public key crypto
 -export([
          %% EQC
@@ -65,6 +68,15 @@
          aead_chacha20poly1305_NONCEBYTES/0,
          aead_chacha20poly1305_ABYTES/0,
          aead_chacha20poly1305_MESSAGEBYTES_MAX/0,
+
+         %% EQC
+         aead_xchacha20poly1305_ietf_encrypt/4,
+         aead_xchacha20poly1305_ietf_decrypt/4, 
+         aead_xchacha20poly1305_ietf_keygen/0,
+         aead_xchacha20poly1305_ietf_KEYBYTES/0,
+         aead_xchacha20poly1305_ietf_NPUBBYTES/0,
+         aead_xchacha20poly1305_ietf_ABYTES/0,
+         aead_xchacha20poly1305_ietf_MESSAGEBYTES_MAX/0,
 
          %% EQC
          stream_key_size/0,
@@ -157,8 +169,6 @@
 %% Internal verification of the system
 -export([verify/0]).
 
-
-
 %% Definitions of system budgets
 %% To get a grip for these, call `enacl_timing:all/0' on your system. The numbers here are
 %% described in the README.md file.
@@ -204,6 +214,19 @@
 -define(CRYPTO_GENERICHASH_KEYBYTES_MAX, 64).
 -define(CRYPTO_GENERICHASH_KEYBYTES, 32).
 
+-define(CRYPTO_AEAD_CHACHA20POLY1305_IETF_NPUBBYTES, 12).
+-define(CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES, 24).
+
+% Helper map for nonce/1
+-define(NONCE_SIZES, 
+        #{
+            stream                      => ?CRYPTO_STREAM_NONCEBYTES,
+            stream_chacha20             => ?CRYPTO_STREAM_CHACHA20_NONCEBYTES,
+            aead_chacha20poly1305_ietf  => ?CRYPTO_AEAD_CHACHA20POLY1305_IETF_NPUBBYTES,
+            aead_xchacha20poly1305_ietf => ?CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES
+         }
+       ).
+
 %% @doc Verify makes sure the constants defined in libsodium matches ours
 verify() ->
     true = equals(binary:copy(<<0>>, enacl_nif:crypto_box_ZEROBYTES()), ?P_ZEROBYTES),
@@ -230,7 +253,9 @@ verify() ->
          {crypto_generichash_BYTES_MAX, ?CRYPTO_GENERICHASH_BYTES_MAX},
          {crypto_generichash_KEYBYTES, ?CRYPTO_GENERICHASH_KEYBYTES},
          {crypto_generichash_KEYBYTES_MIN, ?CRYPTO_GENERICHASH_KEYBYTES_MIN},
-         {crypto_generichash_KEYBYTES_MAX, ?CRYPTO_GENERICHASH_KEYBYTES_MAX}
+         {crypto_generichash_KEYBYTES_MAX, ?CRYPTO_GENERICHASH_KEYBYTES_MAX},
+         {crypto_aead_chacha20poly1305_NPUBBYTES, ?CRYPTO_AEAD_CHACHA20POLY1305_IETF_NPUBBYTES},
+         {crypto_aead_xchacha20poly1305_ietf_NPUBBYTES, ?CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES}
     ],
     run_verifiers(Verifiers).
 
@@ -264,6 +289,16 @@ hash(Bin) ->
             bump(enacl_nif:crypto_hash_b(Bin), ?HASH_REDUCTIONS, ?HASH_SIZE, K);
         _ ->
             enacl_nif:crypto_hash(Bin)
+    end.
+
+%% ----------------------
+%% @doc nonce/1
+%% @end
+-spec nonce(atom()) -> binary() | {error, term()}.
+nonce(NonceType) ->                                          
+    case maps:get(NonceType, ?NONCE_SIZES, none) of 
+        none -> {error, unknown_nonce};
+        Size -> randombytes(Size)
     end.
 
 %% @doc verify_16/2 implements constant time 16-byte binary() verification
@@ -1100,6 +1135,66 @@ aead_chacha20poly1305_ABYTES() ->
 -spec aead_chacha20poly1305_MESSAGEBYTES_MAX() -> pos_integer().
 aead_chacha20poly1305_MESSAGEBYTES_MAX() ->
     enacl_nif:crypto_aead_chacha20poly1305_MESSAGEBYTES_MAX().
+
+%% XChaCha20-Poly1305
+%% ------------------
+%% @doc aead_xchacha20poly1305_ietf_KEYBYTES/0 returns the number of bytes
+%% of the key used in the XChaCha20-Poly1305 construction.
+%% @end
+-spec aead_xchacha20poly1305_ietf_KEYBYTES() -> pos_integer().
+aead_xchacha20poly1305_ietf_KEYBYTES() ->
+    enacl_nif:crypto_aead_xchacha20poly1305_ietf_KEYBYTES().
+
+%% @doc aead_xchacha20poly1305_ietf_NPUBBYTES/0 returns the number of bytes
+%% of the Nonce used in the XChaCha20-Poly1305 construction.
+%% @end
+-spec aead_xchacha20poly1305_ietf_NPUBBYTES() -> pos_integer().
+aead_xchacha20poly1305_ietf_NPUBBYTES() ->
+    enacl_nif:crypto_aead_xchacha20poly1305_ietf_NPUBBYTES().
+
+%% @doc aead_xchacha20poly1305_ietf_ABYTES/0 returns the number of bytes
+%% of the MAC used in the XChaCha20-Poly1305 construction.
+%% @end
+-spec aead_xchacha20poly1305_ietf_ABYTES() -> pos_integer().
+aead_xchacha20poly1305_ietf_ABYTES() ->
+    enacl_nif:crypto_aead_xchacha20poly1305_ietf_ABYTES().
+
+%% @doc aead_chacha20poly1305_ietf_MESSAGEBYTES_MAX/0 returns the max number of bytes
+%% allowed in a message in the XChaCha20-Poly1305 construction.
+%% @end
+-spec aead_xchacha20poly1305_ietf_MESSAGEBYTES_MAX() -> pos_integer().
+aead_xchacha20poly1305_ietf_MESSAGEBYTES_MAX() ->
+    enacl_nif:crypto_aead_xchacha20poly1305_ietf_MESSAGEBYTES_MAX().
+
+%% ----------------------
+%% @doc aead_xchacha20poly1305_ietf_keygen/0 generates a random key is
+%% equivalent to calling `randombytes/1' with `aead_xchacha20poly1305_ietf_KEYBYTES/0`'
+%% @end
+-spec aead_xchacha20poly1305_ietf_keygen() -> binary() | {error, term()}.
+aead_xchacha20poly1305_ietf_keygen() ->                                          
+    enacl_nif:crypto_aead_xchacha20poly1305_ietf_keygen().
+
+%% ----------------------
+%% @doc aead_xchacha20poly1305_ietf_encrypt/4 encrypts `Message' with additional data
+%% `AD' using `Key' and `Nonce'. Returns the encrypted message followed by
+%% `aead_chacha20poly1305_ietf_ABYTES/0' bytes of MAC.
+%% @end
+-spec aead_xchacha20poly1305_ietf_encrypt(binary(), binary(), binary(),
+                                          binary()) -> binary() | {error,
+                                                                   term()}.
+aead_xchacha20poly1305_ietf_encrypt(Message, AD, Nonce, Key) ->
+    enacl_nif:crypto_aead_xchacha20poly1305_ietf_encrypt(Message, AD, Nonce, Key).
+
+%% @doc aead_xchacha20poly1305_ietf_decrypt/4 decrypts ciphertext `CT' with additional
+%% data `AD' using `Key' and `Nonce'. Note: `CipherText' should contain
+%% `aead_xchacha20poly1305_ietf_ABYTES/0' bytes that is the MAC. Returns the decrypted
+%% message.
+%% @end
+-spec aead_xchacha20poly1305_ietf_decrypt(binary(), binary(), binary(),
+                                          binary()) -> binary() | {error,
+                                                                   term()}.
+aead_xchacha20poly1305_ietf_decrypt(CT, AD, Nonce, Key) ->
+    enacl_nif:crypto_aead_xchacha20poly1305_ietf_decrypt(CT, AD, Nonce, Key).
 
 %% Obtaining random bytes
 

--- a/src/enacl_nif.erl
+++ b/src/enacl_nif.erl
@@ -74,6 +74,14 @@
          crypto_aead_chacha20poly1305_ABYTES/0,
          crypto_aead_chacha20poly1305_MESSAGEBYTES_MAX/0,
 
+         crypto_aead_xchacha20poly1305_ietf_encrypt/4,
+         crypto_aead_xchacha20poly1305_ietf_decrypt/4,
+         crypto_aead_xchacha20poly1305_ietf_keygen/0,
+         crypto_aead_xchacha20poly1305_ietf_KEYBYTES/0,
+         crypto_aead_xchacha20poly1305_ietf_NPUBBYTES/0,
+         crypto_aead_xchacha20poly1305_ietf_ABYTES/0,
+         crypto_aead_xchacha20poly1305_ietf_MESSAGEBYTES_MAX/0,
+ 
          crypto_auth_BYTES/0,
          crypto_auth_KEYBYTES/0,
 
@@ -254,6 +262,14 @@ crypto_aead_chacha20poly1305_KEYBYTES()                           -> erlang:nif_
 crypto_aead_chacha20poly1305_NPUBBYTES()                          -> erlang:nif_error(nif_not_loaded).
 crypto_aead_chacha20poly1305_ABYTES()                             -> erlang:nif_error(nif_not_loaded).
 crypto_aead_chacha20poly1305_MESSAGEBYTES_MAX()                   -> erlang:nif_error(nif_not_loaded).
+
+crypto_aead_xchacha20poly1305_ietf_KEYBYTES()                               -> erlang:nif_error(nif_not_loaded).
+crypto_aead_xchacha20poly1305_ietf_NPUBBYTES()                              -> erlang:nif_error(nif_not_loaded).
+crypto_aead_xchacha20poly1305_ietf_ABYTES()                                 -> erlang:nif_error(nif_not_loaded).
+crypto_aead_xchacha20poly1305_ietf_MESSAGEBYTES_MAX()                       -> erlang:nif_error(nif_not_loaded).
+crypto_aead_xchacha20poly1305_ietf_keygen()                                 -> erlang:nif_error(nif_not_loaded).
+crypto_aead_xchacha20poly1305_ietf_encrypt(_Msg, _Ad, _Nonce, _Key)         -> erlang:nif_error(nif_not_loaded).
+crypto_aead_xchacha20poly1305_ietf_decrypt(_Ciphered, _AD, _Nonce, _Key)    -> erlang:nif_error(nif_not_loaded).
 
 crypto_auth_BYTES() -> erlang:nif_error(nif_not_loaded).
 crypto_auth_KEYBYTES() -> erlang:nif_error(nif_not_loaded).


### PR DESCRIPTION
@jlouis if could be so kind to close #31 

This PR to exposes the XChaCha20-Poly1305 construction

TODO:
  - [x]  XChaCha-Poly1305 bindings Implementation
  - [x] Generic nonce/1
  - [x] Tests
 -  [x] Beautify

Notes:

 -  Method of testing prop_nonce works but is dubious, surely there'd an idiomatic eqc way of testing this. It is mainly dubious per output on a failure IMHO. 
- Docs could be a lot better, but we can forgo them in detail for the moment as as soon as this is merged I will be pushing up another PR in regards #32 

