### PR TITLE
Add ops and mem limits to pwhash functions

### DIFF
--- a/c_src/enacl_nif.c
+++ b/c_src/enacl_nif.c
@@ -1781,9 +1781,9 @@ static ErlNifFunc nif_funcs[] = {
 	{"crypto_verify_32", 2, enif_crypto_verify_32},
 	{"sodium_memzero", 1, enif_sodium_memzero},
 
-	{"crypto_pwhash", 4, enif_crypto_pwhash},
-	{"crypto_pwhash_str", 3, enif_crypto_pwhash_str},
-	{"crypto_pwhash_str_verify", 2, enif_crypto_pwhash_str_verify},
+	erl_nif_dirty_job_cpu_bound_macro("crypto_pwhash", 4, enif_crypto_pwhash),
+	erl_nif_dirty_job_cpu_bound_macro("crypto_pwhash_str", 3, enif_crypto_pwhash_str),
+	erl_nif_dirty_job_cpu_bound_macro("crypto_pwhash_str_verify", 2, enif_crypto_pwhash_str_verify),
 
 	erl_nif_dirty_job_cpu_bound_macro("crypto_curve25519_scalarmult", 2, enif_crypto_curve25519_scalarmult),
 	erl_nif_dirty_job_cpu_bound_macro("crypto_curve25519_scalarmult_base", 1, enif_crypto_curve25519_scalarmult_base),

--- a/c_src/enacl_nif.c
+++ b/c_src/enacl_nif.c
@@ -1328,6 +1328,14 @@ ERL_NIF_TERM enif_crypto_pwhash(ErlNifEnv *env, int argc, ERL_NIF_TERM const arg
     return enif_make_badarg(env);
   }
 
+  // Check limits
+  if( (o < crypto_pwhash_OPSLIMIT_MIN) ||
+      (o > crypto_pwhash_OPSLIMIT_MAX) ||
+      (m < crypto_pwhash_MEMLIMIT_MIN) ||
+      (m > crypto_pwhash_MEMLIMIT_MAX) ) {
+    return enif_make_badarg(env);
+  }
+
   // Check Salt size
   if(s.size != crypto_pwhash_SALTBYTES) {
     return nacl_error_tuple(env, "invalid_salt_size");
@@ -1361,6 +1369,14 @@ ERL_NIF_TERM enif_crypto_pwhash_str(ErlNifEnv *env, int argc, ERL_NIF_TERM const
       (!enif_inspect_iolist_as_binary(env, argv[0], &p)) ||
       !(o = enacl_pwhash_opslimit(env, argv[1])) ||
       !(m = enacl_pwhash_memlimit(env, argv[2])) ) {
+    return enif_make_badarg(env);
+  }
+
+  // Check limits
+  if( (o < crypto_pwhash_OPSLIMIT_MIN) ||
+      (o > crypto_pwhash_OPSLIMIT_MAX) ||
+      (m < crypto_pwhash_MEMLIMIT_MIN) ||
+      (m > crypto_pwhash_MEMLIMIT_MAX) ) {
     return enif_make_badarg(env);
   }
 

--- a/src/enacl.erl
+++ b/src/enacl.erl
@@ -101,6 +101,9 @@
          shorthash_size/0,
          shorthash/2,
 
+         %% No Tests!
+         pwhash_str/3,
+
          %% EQC
          pwhash/2,
          pwhash_str/1,
@@ -336,6 +339,7 @@ generichash_final({hashstate, HashSize, HashState}) ->
     enacl_nif:crypto_generichash_final(HashSize, HashState).
 
 
+-type pwhash_limit() :: interactive | moderate | sensitive | pos_integer().
 %% @doc pwhash/2 hash a password
 %%
 %% This function generates a fixed size salted hash of a user defined password.
@@ -347,10 +351,24 @@ pwhash(Password, Salt) ->
 %% @doc pwhash_str/1 generates a ASCII encoded hash of a password
 %%
 %% This function generates a fixed size, salted, ASCII encoded hash of a user defined password.
+%% Defaults to interactive/interactive limits.
 %% @end
 -spec pwhash_str(iodata()) -> {ok, iodata()} | {error, term()}.
 pwhash_str(Password) ->
-    case enacl_nif:crypto_pwhash_str(Password) of
+    pwhash_str(Password, interactive, interactive).
+
+%% @doc pwhash_str/3 generates a ASCII encoded hash of a password
+%%
+%% This function generates a fixed size, salted, ASCII encoded hash of a user defined password
+%% given Ops and Mem limits.
+%% @end
+-spec pwhash_str(Password, Ops, Mem) -> {ok, iodata()} | {error, term()}
+    when
+      Password :: iodata(),
+      Ops :: pwhash_limit(),
+      Mem :: pwhash_limit().
+pwhash_str(Password, Ops, Mem) ->
+    case enacl_nif:crypto_pwhash_str(Password, Ops, Mem) of
         {ok, ASCII} ->
             {ok, strip_null_terminate(ASCII)};
         {error, Reason} ->

--- a/src/enacl.erl
+++ b/src/enacl.erl
@@ -102,6 +102,7 @@
          shorthash/2,
 
          %% No Tests!
+         pwhash/4,
          pwhash_str/3,
 
          %% EQC
@@ -343,10 +344,25 @@ generichash_final({hashstate, HashSize, HashState}) ->
 %% @doc pwhash/2 hash a password
 %%
 %% This function generates a fixed size salted hash of a user defined password.
+%% Defaults to interactive/interactive limits.
 %% @end
 -spec pwhash(iodata(), binary()) -> {ok, binary()} | {error, term()}.
 pwhash(Password, Salt) ->
-    enacl_nif:crypto_pwhash(Password, Salt).
+    pwhash(Password, Salt, interactive, interactive).
+
+%% @doc pwhash/4 hash a password
+%%
+%% This function generates a fixed size salted hash of a user defined password given Ops and Mem
+%% limits.
+%% @end
+-spec pwhash(Password, Salt, Ops, Mem) -> {ok, binary()} | {error, term()}
+    when
+      Password :: iodata(),
+      Salt     :: binary(),
+      Ops      :: pwhash_limit(),
+      Mem      :: pwhash_limit().
+pwhash(Password, Salt, Ops, Mem) ->
+    enacl_nif:crypto_pwhash(Password, Salt, Ops, Mem).
 
 %% @doc pwhash_str/1 generates a ASCII encoded hash of a password
 %%

--- a/src/enacl_nif.erl
+++ b/src/enacl_nif.erl
@@ -133,7 +133,7 @@
 %% Password Hashing - Argon2 Algorithm
 -export([
          crypto_pwhash/2,
-         crypto_pwhash_str/1,
+         crypto_pwhash_str/3,
          crypto_pwhash_str_verify/2
         ]).
 
@@ -189,7 +189,7 @@ crypto_generichash_update(_HashSize, _HashState, _Message) ->  erlang:nif_error(
 crypto_generichash_final(_HashSize, _HashState) ->  erlang:nif_error(nif_not_loaded).
 
 crypto_pwhash(_Password, _Salt) -> erlang:nif_error(nif_not_loaded).
-crypto_pwhash_str(_Password) -> erlang:nif_error(nif_not_loaded).
+crypto_pwhash_str(_Password, _Ops, _Mem) -> erlang:nif_error(nif_not_loaded).
 crypto_pwhash_str_verify(_HashedPassword, _Password) -> erlang:nif_error(nif_not_loaded).
 
 crypto_box_NONCEBYTES() -> erlang:nif_error(nif_not_loaded).

--- a/src/enacl_nif.erl
+++ b/src/enacl_nif.erl
@@ -132,7 +132,7 @@
 
 %% Password Hashing - Argon2 Algorithm
 -export([
-         crypto_pwhash/2,
+         crypto_pwhash/4,
          crypto_pwhash_str/3,
          crypto_pwhash_str_verify/2
         ]).
@@ -188,7 +188,7 @@ crypto_generichash_init(_HashSize, _Key) ->  erlang:nif_error(nif_not_loaded).
 crypto_generichash_update(_HashSize, _HashState, _Message) ->  erlang:nif_error(nif_not_loaded).
 crypto_generichash_final(_HashSize, _HashState) ->  erlang:nif_error(nif_not_loaded).
 
-crypto_pwhash(_Password, _Salt) -> erlang:nif_error(nif_not_loaded).
+crypto_pwhash(_Password, _Salt, _Ops, _Mem) -> erlang:nif_error(nif_not_loaded).
 crypto_pwhash_str(_Password, _Ops, _Mem) -> erlang:nif_error(nif_not_loaded).
 crypto_pwhash_str_verify(_HashedPassword, _Password) -> erlang:nif_error(nif_not_loaded).
 


### PR DESCRIPTION
With these commits, the pwhash family of functions can accept either atoms (`interactive`, `moderate`, or `sensitive`) or positive integers (within `crypto_pwhash_(OPS/MEM)LIMIT_(MAX/MIN)`).

The versions that don't take limits are maintained, and simply default to interactive/interactive as they did before.