### PR TITLE
Move rebar3_hex into project_plugins

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,8 @@
 {erl_opts, [debug_info]}.
 
-{plugins, [pc, rebar3_hex]}.
+{plugins, [pc]}.
+
+{project_plugins, [rebar3_hex]}.
 
 {provider_hooks, [
     {pre, [


### PR DESCRIPTION
This change will prevent users from having to download rebar3_hex and all of it's dependencies.