### PR TITLE
Remove arch indication for Darwin. Partially fixes #53

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -18,9 +18,9 @@
 ]}.
 
 {port_env, [
-    {"darwin", "CFLAGS", "$CFLAGS -fPIC -O3 -std=c99 -arch x86_64 -finline-functions -Wall -Wmissing-prototypes"},
-    {"darwin", "CXXFLAGS", "$CXXFLAGS -fPIC -O3 -arch x86_64 -finline-functions -Wall"},
-    {"darwin", "LDFLAGS", "$LDFLAGS -arch x86_64 -flat_namespace -undefined suppress -lsodium"},
+    {"darwin", "CFLAGS", "$CFLAGS -fPIC -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes"},
+    {"darwin", "CXXFLAGS", "$CXXFLAGS -fPIC -O3 -finline-functions -Wall"},
+    {"darwin", "LDFLAGS", "$LDFLAGS -flat_namespace -undefined suppress -lsodium"},
 
     {"linux", "CFLAGS", "$CFLAGS -fPIC -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes"},
     {"linux", "CXXFLAGS", "$CXXFLAGS -fPIC -O3 -finline-functions -Wall"},


### PR DESCRIPTION
I'm unsure why it's specified since darwin has been uni-arch for ages, but the arm version is smart enough to know which arch to build.

M1 Mac Mini
```
dabaer@Mac-mini enacl % uname -m
arm64
dabaer@Mac-mini enacl % make compile
rebar3 compile
===> Verifying dependencies...
===> Compiling c_src/aead.c
===> Compiling c_src/enacl.c
===> Compiling c_src/enacl_ext.c
===> Compiling c_src/enacl_nif.c
===> Compiling c_src/generichash.c
===> Compiling c_src/hash.c
===> Compiling c_src/kdf.c
===> Compiling c_src/kx.c
===> Compiling c_src/public.c
===> Compiling c_src/pwhash.c
===> Compiling c_src/randombytes.c
===> Compiling c_src/secret.c
===> Compiling c_src/secretstream.c
===> Compiling c_src/sign.c
===> Linking /Users/jadenn/Documents/arviksa/enacl/priv/enacl_nif.so
===> Analyzing applications...
===> Compiling enacl
dabaer@Mac-mini enacl % make tests
rebar3 ct
===> Verifying dependencies...
===> Analyzing applications...
===> Compiling enacl
===> Running Common Test suites...
%%% enacl_SUITE: ..........
All 10 tests passed.
```

Intel Mac Mini
```
Dakoras-Mini:enacl dakora$ uname -m
x86_64
Dakoras-Mini:enacl dakora$ make compile
rebar3 compile
===> Verifying dependencies...
===> Compiling c_src/aead.c
===> Compiling c_src/enacl.c
===> Compiling c_src/enacl_ext.c
===> Compiling c_src/enacl_nif.c
===> Compiling c_src/generichash.c
===> Compiling c_src/hash.c
===> Compiling c_src/kdf.c
===> Compiling c_src/kx.c
===> Compiling c_src/public.c
===> Compiling c_src/pwhash.c
===> Compiling c_src/randombytes.c
===> Compiling c_src/secret.c
===> Compiling c_src/secretstream.c
===> Compiling c_src/sign.c
===> Linking /Users/dakora/enacl/priv/enacl_nif.so
===> Analyzing applications...
===> Compiling enacl
Dakoras-Mini:enacl dakora$ make tests
rebar3 ct
===> Verifying dependencies...
===> Analyzing applications...
===> Compiling enacl
===> Running Common Test suites...
%%% enacl_SUITE: ..........
All 10 tests passed.
```