### PR TITLE
remove x86 from darwin config

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -18,9 +18,9 @@
 ]}.
 
 {port_env, [
-    {"darwin", "CFLAGS", "$CFLAGS -fPIC -O3 -std=c99 -arch x86_64 -finline-functions -Wall -Wmissing-prototypes"},
-    {"darwin", "CXXFLAGS", "$CXXFLAGS -fPIC -O3 -arch x86_64 -finline-functions -Wall"},
-    {"darwin", "LDFLAGS", "$LDFLAGS -arch x86_64 -flat_namespace -undefined suppress -lsodium"},
+    {"darwin", "CFLAGS", "$CFLAGS -fPIC -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes"},
+    {"darwin", "CXXFLAGS", "$CXXFLAGS -fPIC -O3 -finline-functions -Wall"},
+    {"darwin", "LDFLAGS", "$LDFLAGS -flat_namespace -undefined suppress -lsodium"},
 
     {"linux", "CFLAGS", "$CFLAGS -fPIC -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes"},
     {"linux", "CXXFLAGS", "$CXXFLAGS -fPIC -O3 -finline-functions -Wall"},

--- a/rebar.config
+++ b/rebar.config
@@ -18,9 +18,9 @@
 ]}.
 
 {port_env, [
-    {"darwin", "CFLAGS", "$CFLAGS -fPIC -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes"},
+    {"darwin", "CFLAGS", "$CFLAGS -I/usr/local/include -I/opt/homebrew/include -fPIC -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes"},
     {"darwin", "CXXFLAGS", "$CXXFLAGS -fPIC -O3 -finline-functions -Wall"},
-    {"darwin", "LDFLAGS", "$LDFLAGS -flat_namespace -undefined suppress -lsodium"},
+    {"darwin", "LDFLAGS", "$LDFLAGS -flat_namespace -undefined suppress -L/usr/local/lib -L/opt/homebrew/lib -lsodium"},
 
     {"linux", "CFLAGS", "$CFLAGS -fPIC -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes"},
     {"linux", "CXXFLAGS", "$CXXFLAGS -fPIC -O3 -finline-functions -Wall"},


### PR DESCRIPTION
Remove the `-arch x86_64` flag to allow build on arm64 Macs.