### PR TITLE
Use dirty schedulers unconditionally

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {erl_opts, [debug_info]}.
 
-{plugins, [pc]}.
+{plugins, [{pc, "~> 1.15"}]}.
 
 {project_plugins, [rebar3_hex]}.
 


### PR DESCRIPTION
Remove check for ERL_NIF_DIRTY_JOB_CPU_BOUND for two reasons:
1. #ifdef ERL_NIF_DIRTY_JOB_CPU_BOUND check is incorrect because ERL_NIF_DIRTY_JOB_CPU_BOUND is a enum
2. Erlang support for dirty schedulers is unconditional since 2016