### PR TITLE
Adds arm64 compilation for M1 Macs

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -18,9 +18,9 @@
 ]}.
 
 {port_env, [
-    {"darwin", "CFLAGS", "$CFLAGS -fPIC -O3 -std=c99 -arch x86_64 -finline-functions -Wall -Wmissing-prototypes"},
-    {"darwin", "CXXFLAGS", "$CXXFLAGS -fPIC -O3 -arch x86_64 -finline-functions -Wall"},
-    {"darwin", "LDFLAGS", "$LDFLAGS -arch x86_64 -flat_namespace -undefined suppress -lsodium"},
+    {"darwin", "CFLAGS", "$CFLAGS -fPIC -O3 -std=c99 -arch x86_64 -arch arm64 -finline-functions -Wall -Wmissing-prototypes"},
+    {"darwin", "CXXFLAGS", "$CXXFLAGS -fPIC -O3 -arch x86_64 -arch arm64 -finline-functions -Wall"},
+    {"darwin", "LDFLAGS", "$LDFLAGS -arch x86_64 -arch arm64 -flat_namespace -undefined suppress -lsodium"},
 
     {"linux", "CFLAGS", "$CFLAGS -fPIC -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes"},
     {"linux", "CXXFLAGS", "$CXXFLAGS -fPIC -O3 -finline-functions -Wall"},


### PR DESCRIPTION
This adds arm64 compilation flags so enacl can work on M1 macs