### PR TITLE
Fix unload callback function signature.

### DIFF
--- a/c_src/enacl_nif.c
+++ b/c_src/enacl_nif.c
@@ -54,9 +54,7 @@ static int enacl_crypto_upgrade(ErlNifEnv* env, void **priv_data,
     return 0;
 }
 
-static int enacl_crypto_unload(ErlNifEnv* env, void **priv_data,
-                                ERL_NIF_TERM load_info) {
-    return 0;
+static void enacl_crypto_unload(ErlNifEnv* env, void *priv_data) {
 }
 
 /* GENERAL ROUTINES


### PR DESCRIPTION
Fixes #73. Uses function signature documented in [erts](https://www.erlang.org/doc/apps/erts/erl_nif.html).

I have no idea why this worked in most circumstances.