### PR TITLE
Fix the PC version

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {erl_opts, [debug_info]}.
 
-{plugins, [pc]}.
+{plugins, [{pc, "1.15.0"}]}.
 
 {project_plugins, [rebar3_hex]}.
 


### PR DESCRIPTION
I had similar issues to a report that was described here:

https://elixirforum.com/t/compile-error-in-syslog-since-upgrading-to-erlang-27/66606

```sh
% rebar3 pc compile
===> Verifying dependencies...
make: 對「libsodium」無需做任何事。
===> Uncaught error in rebar_core. Run with DIAGNOSTIC=1 to see stacktrace or consult rebar3.crashdump
===> When submitting a bug report, please include the output of `rebar3 report "your command"`
```

For those with the issue, clearing out the _build directory may be needed.


Note I did not test this patch on the `v1.2.1` release, instead i tested it on a version of enacl with a vendored libsodium. If you are interested in the vendored version let me know as I can prepare a patch for upstreaming.