### PR TITLE
Fixes for compilation with newer compilers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.2.2]
+
+### Fixed [1.2.2]
+
+- Removed `-arch` flags from darwin build config for Apple Silicon compatibility
+- Added `/usr/local/lib` and `/opt/homebrew/lib` references to the same for simpler build setup.
+
 ## [1.2.1]
 
 ### Fixed [1.2.1]

--- a/c_src/enacl_nif.c
+++ b/c_src/enacl_nif.c
@@ -54,9 +54,7 @@ static int enacl_crypto_upgrade(ErlNifEnv* env, void **priv_data,
     return 0;
 }
 
-static int enacl_crypto_unload(ErlNifEnv* env, void **priv_data,
-                                ERL_NIF_TERM load_info) {
-    return 0;
+static void enacl_crypto_unload(ErlNifEnv* env, void *priv_data) {
 }
 
 /* GENERAL ROUTINES

--- a/fork_maintenance.md
+++ b/fork_maintenance.md
@@ -9,10 +9,6 @@ Plan is:
   + upstream commits, if any, move from `master` to `dev`
     (can use `merge`, `cherry-pick`, or whatever works best at the time)
   + tag notable commits in dev; keep changelog updated with those
-  + use `ref` in dependencies to point to dev commit hashes
-    (eventually shift to the tags for readability, but wait until we have some
-     [tag-protection-rules](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-tag-protection-rules
-) setup to ensure the same tag always points to the same commit
 
 The overall goal is to allow for further development on this repo without worrying
 too much about the upstream from which it was forked.

--- a/fork_maintenance.md
+++ b/fork_maintenance.md
@@ -1,0 +1,18 @@
+## Fork maintenance
+
+Plan is:
+- keep `master` up to date with the upstream; no commits from us
+  + We're not expecting too many more commits from the upstream,
+    but should any emerge, they could be included trivially.
+- use `dev` as our effective trunk branch:
+  + topic branches are merged into dev
+  + upstream commits, if any, move from `master` to `dev`
+    (can use `merge`, `cherry-pick`, or whatever works best at the time)
+  + tag notable commits in dev; keep changelog updated with those
+  + use `ref` in dependencies to point to dev commit hashes
+    (eventually shift to the tags for readability, but wait until we have some
+     [tag-protection-rules](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-tag-protection-rules
+) setup to ensure the same tag always points to the same commit
+
+The overall goal is to allow for further development on this repo without worrying
+too much about the upstream from which it was forked.

--- a/rebar.config
+++ b/rebar.config
@@ -18,9 +18,11 @@
 ]}.
 
 {port_env, [
-    {"darwin", "CFLAGS", "$CFLAGS -fPIC -O3 -std=c99 -arch x86_64 -finline-functions -Wall -Wmissing-prototypes"},
-    {"darwin", "CXXFLAGS", "$CXXFLAGS -fPIC -O3 -arch x86_64 -finline-functions -Wall"},
-    {"darwin", "LDFLAGS", "$LDFLAGS -arch x86_64 -flat_namespace -undefined suppress -lsodium"},
+    {"darwin", "CFLAGS", "$CFLAGS -I/usr/local/include -I/opt/homebrew/include"
+      " -fPIC -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes"},
+    {"darwin", "CXXFLAGS", "$CXXFLAGS -fPIC -O3 -finline-functions -Wall"},
+    {"darwin", "LDFLAGS", "$LDFLAGS -flat_namespace -undefined suppress"
+      " -L/usr/local/lib -L/opt/homebrew/lib -lsodium"},
 
     {"linux", "CFLAGS", "$CFLAGS -fPIC -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes"},
     {"linux", "CXXFLAGS", "$CXXFLAGS -fPIC -O3 -finline-functions -Wall"},

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {erl_opts, [debug_info]}.
 
-{plugins, [pc]}.
+{plugins, [{pc, "~> 1.15"}]}.
 
 {project_plugins, [rebar3_hex]}.
 


### PR DESCRIPTION
* Force use of latest pc plugin (by default rebar grabs an old version which crashes)
* Fix bad signature on NIF unload function, which is now a compile error in recent versions of clang.